### PR TITLE
fixed and organized package.jsons

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,13 +4,17 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "jquery": "^3.4.1",
     "mdbreact": "^4.22.0",
-    "react": "^16.10.1",
+    "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.14",
-    "react-dom": "^16.10.1",
+    "react-dom": "^16.12.0",
     "react-motion": "^0.5.2",
+    "react-redux": "^7.1.3",
     "react-scripts": "3.1.2",
-    "react-text-collapse": "^0.5.2"
+    "react-text-collapse": "^0.5.2",
+    "redux": "^4.0.0",
+    "typescript": "^2.8.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -34,6 +38,7 @@
     ]
   },
   "devDependencies": {
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "react-router-dom": "^5.1.2"
   },
   "proxy": "http://localhost:5000"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "concurrently \"nodemon server/server.js\" \"cd client && npm run start\"",
     "build": "cd client && npm build",
     "start": "node server/server.js",
-    "heroku-postbuild": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm run build"
+    "heroku-postbuild": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm run build",
+    "eslint": "eslint server && cd client && eslint src"
   },
   "repository": {
     "type": "git",
@@ -34,18 +35,14 @@
     "morgan": "^1.9.1",
     "nodemon": "^1.18.10",
     "prop-types": "^15.7.2",
-    "react-redux": "^7.1.1",
-    "reactstrap": "^8.1.1",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
     "should": "^13.2.3",
-    "supertest": "^4.0.2",
-    "react-bootstrap": "1.0.0-beta.14"
+    "supertest": "^4.0.2"
   },
   "homepage": "https://github.com/CEN3031Group2c/TrinityCaskets",
   "devDependencies": {
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-mocha": "^6.2.1",
-    "eslint-plugin-react": "^7.16.0"
+    "dotenv": "^8.2.0",
+    "eslint-plugin-mocha": "^6.2.1"
   }
 }


### PR DESCRIPTION
moved react stuff to client package.json.
added peer dependencies to package.jsons.
running npm install or npm run-script install-all will not throw warnings anymore.