### PR TITLE
add .env and support for env variables instead of config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ client/build
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -1,3 +1,7 @@
+if (process.env.NODE_ENV !== 'production') {
+    require('dotenv').config()
+}
+
 const path = require('path'),
     express = require('express'),
     mongoose = require('mongoose'),
@@ -9,6 +13,7 @@ module.exports.init = () => {
         connect to database
         - reference README for db uri
     */
+   console.log(process.env.DB_URI || 'no process.env.DB_URI found')
     mongoose.connect(process.env.DB_URI || require('./config').db.uri, {
         useNewUrlParser: true
     });

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -12,7 +12,7 @@ function authMiddleware(req, res, next) {
 
     try {
         // Verify token is valid
-        const decoded = jwt.verify(token, require('../config/config').jwt.jwtSecret);
+        const decoded = jwt.verify(token, process.env.JWT_SECRET || require('../config/config').jwt.jwtSecret);
         // Grab the user from the payload and set it as the request
         req.user = decoded;
         next();

--- a/server/routes/authentication.routes.js
+++ b/server/routes/authentication.routes.js
@@ -32,7 +32,7 @@ router.post('/', (req, res) => {
             // If it does match, want to send token back
             jwt.sign(
                 { id: user.id },
-                require('../config/config').jwt.jwtSecret,
+                process.env.JWT_SECRET || require('../config/config').jwt.jwtSecret,
                 (err, token) => {
                     if(err) throw err;
                     res.json({

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -7,7 +7,6 @@ const router = express.Router();
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 // To get our secret key
-const config = require('../config/config');
 
 
 // User Model
@@ -52,7 +51,7 @@ router.post('/', (req, res) =>{
                         // User id is token identifier
                         { id: user.id },
                         // Secret key
-                        config.jwt.jwtSecret,
+                        process.env.JWT_SECRET || require('../config/config').jwt.jwtSecret,
                         (err, token) => {
                             if(err) throw err;
 


### PR DESCRIPTION
added support for .env files in root of project.
This means you can add env variables for keys, like DB_URI.
This is so that heroku can use env variables instead of config.js.
config.js is still supported, but we should switch to using .env so that it is more uniform in the future.